### PR TITLE
Update and minimize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,16 @@ travis-ci = { repository = "ipinfo/rust", branch = "master" }
 codecov = { repository = "ipinfo/rust", branch = "master", service = "github" }
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "blocking"] }
-lru = "0.10.0"
+reqwest = { version = "0.11", features = ["json"] }
+lru = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-include_dir = "0.7.3"
 ipnetwork = "0.20.0"
-tokio = { version = "1", features = ["macros", "time"] }
+tokio = { version = "1", features = ["time"] }
 lazy_static = "1.4"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
- crate no longer requires reqwest `blocking` feature.

- LRU v0.12.1 primarly updates to the latest version of `hashbrown`.

- `include_dir` was an unused dependency

- tokio `macros` and runtime features are only needed for tests and examples.