### PR TITLE
Revert "Add IPv6 support"

### DIFF
--- a/src/ipinfo.rs
+++ b/src/ipinfo.rs
@@ -31,10 +31,6 @@ use tokio::time::timeout;
 
 const COUNTRY_FLAG_URL: &str =
     "https://cdn.ipinfo.io/static/images/countries-flags/";
-
-const BASE_URL: &str = "https://ipinfo.io";
-const BASE_URL_V6: &str = "https://v6.ipinfo.io";
-
 /// IpInfo structure configuration.
 pub struct IpInfoConfig {
     /// IPinfo access token.
@@ -79,6 +75,7 @@ impl Default for IpInfoConfig {
 
 /// IPinfo requests context structure.
 pub struct IpInfo {
+    url: String,
     token: Option<String>,
     client: reqwest::Client,
     cache: LruCache<String, IpDetails>,
@@ -119,7 +116,10 @@ impl IpInfo {
         let client =
             reqwest::Client::builder().timeout(config.timeout).build()?;
 
+        let url = "https://ipinfo.io".to_owned();
+
         let mut ipinfo_obj = Self {
+            url,
             client,
             token: config.token,
             cache: LruCache::new(
@@ -260,7 +260,7 @@ impl IpInfo {
     ) -> Result<HashMap<String, IpDetails>, IpError> {
         // Lookup cache misses which are not bogon
         let response = client
-            .post(&format!("{}/batch", BASE_URL))
+            .post(&format!("{}/batch", self.url))
             .headers(Self::construct_headers())
             .bearer_auth(self.token.as_deref().unwrap_or_default())
             .json(&json!(ips))
@@ -303,18 +303,6 @@ impl IpInfo {
     /// }
     /// ```
     pub async fn lookup(&mut self, ip: &str) -> Result<IpDetails, IpError> {
-        self._lookup(ip, BASE_URL).await
-    }
-
-    pub async fn lookup_v6(&mut self, ip: &str) -> Result<IpDetails, IpError> {
-        self._lookup(ip, BASE_URL_V6).await
-    }
-
-    async fn _lookup(
-        &mut self,
-        ip: &str,
-        base_url: &str,
-    ) -> Result<IpDetails, IpError> {
         if is_bogon(ip) {
             return Ok(IpDetails {
                 ip: ip.to_string(),
@@ -333,7 +321,7 @@ impl IpInfo {
         // lookup in case of a cache miss
         let response = self
             .client
-            .get(&format!("{}/{}", base_url, ip))
+            .get(&format!("{}/{}", self.url, ip))
             .headers(Self::construct_headers())
             .bearer_auth(self.token.as_deref().unwrap_or_default())
             .send()
@@ -382,7 +370,7 @@ impl IpInfo {
             return Err(err!(MapLimitError));
         }
 
-        let map_url = &format!("{}/tools/map?cli=1", BASE_URL);
+        let map_url = &format!("{}/tools/map?cli=1", self.url);
         let client = self.client.clone();
         let json_ips = serde_json::json!(ips);
 


### PR DESCRIPTION
Reverts ipinfo/rust#51

I think the motivation of this change is to allow users of this library to connect to the `ipinfo.io` API using IPv6. Before this change only the IPv4 domain is used.

In my opinion #51 did not improve the status-quo in the right way. A few thoughts:

`lookup_v6` misleads users as to what it does. Because of the missing type information and documentation the name wrongly implies that `lookup(&str)` only works on IPv4 addresses while `lookup_v6(&str)` deals with IPv6 addresses. This is not true and is confusing.

If we do want to give users more control over these kinds lower level decisions then I think we would be better off allowing the user to provide their own [reqwest::Client](https://docs.rs/reqwest/latest/reqwest/struct.Client.html). Then they can use [local_address](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.local_address) to bind to a particular local address.

Choice between using `lookup_v6` and `lookup` methods should _almost never_ be a compile time decision. When I compile my binary I do not know if it will be running in an IPv4 only, IPv6 only, or Both environment.

On this note I think this change should be reworked. I would recommend making IPv4 vs IPv6 address choice transparent. Try to use v6 and then fallback to v4 after a connection failure.