### PR TITLE
Release 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ipinfo"
 description = "ipinfo: A Rust library for IPInfo"
-version = "3.0.0"
+version = "3.1.0"
 authors = [
     "Amr Ali <amralicc@gmail.com>",
     "Uman Shahzad <uman@mslm.io>",


### PR DESCRIPTION
The last safe commit to make a patch update is de4dd4f81f308e76d9e34c54726bcab3e7b8cb6b. Before that every individual PR could also be made a patch.

Past those patches `is_bogon_addr` from #50 requires a minor version bump. I will work on a changelog.