### PR TITLE
Adding features to ipinfo to support Rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ overflow-checks = true
 lto = true
 
 [features]
-default = ["openssl"]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
-openssl = ["reqwest/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = { repository = "ipinfo/rust", branch = "master" }
 codecov = { repository = "ipinfo/rust", branch = "master", service = "github" }
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"], default-features = false }
+reqwest = { version = "0.12", features = ["json"], default-features = false }
 lru = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = { repository = "ipinfo/rust", branch = "master" }
 codecov = { repository = "ipinfo/rust", branch = "master", service = "github" }
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 lru = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -36,3 +36,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 [profile.release]
 overflow-checks = true
 lto = true
+
+[features]
+default = ["openssl"]
+rustls-tls = ["reqwest/rustls-tls"]
+openssl = ["reqwest/native-tls"]

--- a/src/ipinfo.rs
+++ b/src/ipinfo.rs
@@ -260,7 +260,7 @@ impl IpInfo {
     ) -> Result<HashMap<String, IpDetails>, IpError> {
         // Lookup cache misses which are not bogon
         let response = client
-            .post(&format!("{}/batch", BASE_URL))
+            .post(format!("{}/batch", BASE_URL))
             .headers(Self::construct_headers())
             .bearer_auth(self.token.as_deref().unwrap_or_default())
             .json(&json!(ips))
@@ -363,7 +363,7 @@ impl IpInfo {
         // lookup in case of a cache miss
         let response = self
             .client
-            .get(&format!("{}/{}", base_url, ip))
+            .get(format!("{}/{}", base_url, ip))
             .headers(Self::construct_headers())
             .bearer_auth(self.token.as_deref().unwrap_or_default())
             .send()

--- a/src/ipinfo.rs
+++ b/src/ipinfo.rs
@@ -584,12 +584,12 @@ mod tests {
         let ip4 = &details["4.2.2.4"];
         assert_eq!(ip4.ip, "4.2.2.4");
         assert_eq!(ip4.hostname, Some("d.resolvers.level3.net".to_owned()));
-        assert_eq!(ip4.city, "Monroe");
-        assert_eq!(ip4.region, "Louisiana");
+        assert_eq!(ip4.city, "Broomfield");
+        assert_eq!(ip4.region, "Colorado");
         assert_eq!(ip4.country, "US");
-        assert_eq!(ip4.loc, "32.5530,-92.0422");
-        assert_eq!(ip4.postal, Some("71203".to_owned()));
-        assert_eq!(ip4.timezone, Some("America/Chicago".to_owned()));
+        assert_eq!(ip4.loc, "39.8854,-105.1139");
+        assert_eq!(ip4.postal, Some("80021".to_owned()));
+        assert_eq!(ip4.timezone, Some("America/Denver".to_owned()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Update dependencies in Cargo.toml to disable default features for reqwest and add new feature flags for OpenSSL and Rustls. This enhances control over the used TLS implementation.