### PR TITLE
Update Bulgaria currency from BGN to EUR

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -542,7 +542,7 @@ lazy_static! {
             "BD" : { "code": "BDT" ,"symbol": "৳"},
             "BE" : { "code": "EUR" ,"symbol": "€"},
             "BF" : { "code": "XOF" ,"symbol": "CFA"},
-            "BG" : { "code": "BGN" ,"symbol": "лв"},
+            "BG" : { "code": "EUR" ,"symbol": "€"},
             "BH" : { "code": "BHD" ,"symbol": ".د.ب"},
             "BI" : { "code": "BIF" ,"symbol": "FBu"},
             "BJ" : { "code": "XOF" ,"symbol": "CFA"},

--- a/src/ipinfo.rs
+++ b/src/ipinfo.rs
@@ -139,35 +139,11 @@ impl IpInfo {
             base_url: config.base_url.unwrap_or_else(|| BASE_URL.to_string()),
         };
 
-        if config.defaut_countries.is_none() {
-            ipinfo_obj.countries = COUNTRIES.clone();
-        } else {
-            ipinfo_obj.countries = config.defaut_countries.unwrap();
-        }
-
-        if config.default_eu.is_none() {
-            ipinfo_obj.eu = EU.clone();
-        } else {
-            ipinfo_obj.eu = config.default_eu.unwrap();
-        }
-
-        if config.default_flags.is_none() {
-            ipinfo_obj.country_flags = FLAGS.clone();
-        } else {
-            ipinfo_obj.country_flags = config.default_flags.unwrap();
-        }
-
-        if config.default_currencies.is_none() {
-            ipinfo_obj.country_currencies = CURRENCIES.clone();
-        } else {
-            ipinfo_obj.country_currencies = config.default_currencies.unwrap();
-        }
-
-        if config.default_continents.is_none() {
-            ipinfo_obj.continents = CONTINENTS.clone();
-        } else {
-            ipinfo_obj.continents = config.default_continents.unwrap();
-        }
+        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
+        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo.rs
+++ b/src/ipinfo.rs
@@ -139,11 +139,17 @@ impl IpInfo {
             base_url: config.base_url.unwrap_or_else(|| BASE_URL.to_string()),
         };
 
-        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.countries =
+            config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
         ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
-        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
-        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
-        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
+        ipinfo_obj.country_flags =
+            config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config
+            .default_currencies
+            .unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config
+            .default_continents
+            .unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo_core.rs
+++ b/src/ipinfo_core.rs
@@ -112,11 +112,17 @@ impl IpInfoCore {
             continents: HashMap::new(),
         };
 
-        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.countries =
+            config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
         ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
-        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
-        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
-        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
+        ipinfo_obj.country_flags =
+            config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config
+            .default_currencies
+            .unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config
+            .default_continents
+            .unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo_core.rs
+++ b/src/ipinfo_core.rs
@@ -112,35 +112,11 @@ impl IpInfoCore {
             continents: HashMap::new(),
         };
 
-        if config.defaut_countries.is_none() {
-            ipinfo_obj.countries = COUNTRIES.clone();
-        } else {
-            ipinfo_obj.countries = config.defaut_countries.unwrap();
-        }
-
-        if config.default_eu.is_none() {
-            ipinfo_obj.eu = EU.clone();
-        } else {
-            ipinfo_obj.eu = config.default_eu.unwrap();
-        }
-
-        if config.default_flags.is_none() {
-            ipinfo_obj.country_flags = FLAGS.clone();
-        } else {
-            ipinfo_obj.country_flags = config.default_flags.unwrap();
-        }
-
-        if config.default_currencies.is_none() {
-            ipinfo_obj.country_currencies = CURRENCIES.clone();
-        } else {
-            ipinfo_obj.country_currencies = config.default_currencies.unwrap();
-        }
-
-        if config.default_continents.is_none() {
-            ipinfo_obj.continents = CONTINENTS.clone();
-        } else {
-            ipinfo_obj.continents = config.default_continents.unwrap();
-        }
+        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
+        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo_lite.rs
+++ b/src/ipinfo_lite.rs
@@ -112,35 +112,11 @@ impl IpInfoLite {
             continents: HashMap::new(),
         };
 
-        if config.defaut_countries.is_none() {
-            ipinfo_obj.countries = COUNTRIES.clone();
-        } else {
-            ipinfo_obj.countries = config.defaut_countries.unwrap();
-        }
-
-        if config.default_eu.is_none() {
-            ipinfo_obj.eu = EU.clone();
-        } else {
-            ipinfo_obj.eu = config.default_eu.unwrap();
-        }
-
-        if config.default_flags.is_none() {
-            ipinfo_obj.country_flags = FLAGS.clone();
-        } else {
-            ipinfo_obj.country_flags = config.default_flags.unwrap();
-        }
-
-        if config.default_currencies.is_none() {
-            ipinfo_obj.country_currencies = CURRENCIES.clone();
-        } else {
-            ipinfo_obj.country_currencies = config.default_currencies.unwrap();
-        }
-
-        if config.default_continents.is_none() {
-            ipinfo_obj.continents = CONTINENTS.clone();
-        } else {
-            ipinfo_obj.continents = config.default_continents.unwrap();
-        }
+        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
+        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo_lite.rs
+++ b/src/ipinfo_lite.rs
@@ -112,11 +112,17 @@ impl IpInfoLite {
             continents: HashMap::new(),
         };
 
-        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.countries =
+            config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
         ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
-        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
-        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
-        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
+        ipinfo_obj.country_flags =
+            config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config
+            .default_currencies
+            .unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config
+            .default_continents
+            .unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo_plus.rs
+++ b/src/ipinfo_plus.rs
@@ -112,11 +112,17 @@ impl IpInfoPlus {
             continents: HashMap::new(),
         };
 
-        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.countries =
+            config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
         ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
-        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
-        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
-        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
+        ipinfo_obj.country_flags =
+            config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config
+            .default_currencies
+            .unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config
+            .default_continents
+            .unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }

--- a/src/ipinfo_plus.rs
+++ b/src/ipinfo_plus.rs
@@ -112,35 +112,11 @@ impl IpInfoPlus {
             continents: HashMap::new(),
         };
 
-        if config.defaut_countries.is_none() {
-            ipinfo_obj.countries = COUNTRIES.clone();
-        } else {
-            ipinfo_obj.countries = config.defaut_countries.unwrap();
-        }
-
-        if config.default_eu.is_none() {
-            ipinfo_obj.eu = EU.clone();
-        } else {
-            ipinfo_obj.eu = config.default_eu.unwrap();
-        }
-
-        if config.default_flags.is_none() {
-            ipinfo_obj.country_flags = FLAGS.clone();
-        } else {
-            ipinfo_obj.country_flags = config.default_flags.unwrap();
-        }
-
-        if config.default_currencies.is_none() {
-            ipinfo_obj.country_currencies = CURRENCIES.clone();
-        } else {
-            ipinfo_obj.country_currencies = config.default_currencies.unwrap();
-        }
-
-        if config.default_continents.is_none() {
-            ipinfo_obj.continents = CONTINENTS.clone();
-        } else {
-            ipinfo_obj.continents = config.default_continents.unwrap();
-        }
+        ipinfo_obj.countries = config.defaut_countries.unwrap_or_else(|| COUNTRIES.clone());
+        ipinfo_obj.eu = config.default_eu.unwrap_or_else(|| EU.clone());
+        ipinfo_obj.country_flags = config.default_flags.unwrap_or_else(|| FLAGS.clone());
+        ipinfo_obj.country_currencies = config.default_currencies.unwrap_or_else(|| CURRENCIES.clone());
+        ipinfo_obj.continents = config.default_continents.unwrap_or_else(|| CONTINENTS.clone());
 
         Ok(ipinfo_obj)
     }


### PR DESCRIPTION
Bulgaria adopted the Euro starting 1/1/26, this PR changes the country currency code and symbol to reflect that.